### PR TITLE
9 setup accelerometers to generate interrupts when the device is moved from a stationary position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ Output/
 *.jlink
 dfu_images/bl_sd_settings_app.hex
 dfu_images/bl_settings.hex
+dfu_images/trailer_leveler_application*.zip
 TrailerLeveler_pca10056_s140.emSession

--- a/Components/Bluetooth/Bluetooth.c
+++ b/Components/Bluetooth/Bluetooth.c
@@ -46,7 +46,7 @@
 #define MANUFACTURER_NAME               "Kane"                                  /**< Manufacturer. Will be passed to Device Information Service. */
 #define APP_ADV_INTERVAL                300                                     /**< The advertising interval (in units of 0.625 ms. This value corresponds to 187.5 ms). */
 
-#define APP_ADV_DURATION                00                                      /**< The advertising duration in units of 10 milliseconds. 0 means there is no timeout*/
+#define APP_ADV_DURATION                500                                      /**< The advertising duration in units of 10 milliseconds. 0 means there is no timeout*/
 #define APP_BLE_OBSERVER_PRIO           3                                       /**< Application's BLE observer priority. You shouldn't need to modify this value. */
 #define APP_BLE_CONN_CFG_TAG            1                                       /**< A tag identifying the SoftDevice BLE configuration. */
 
@@ -407,8 +407,21 @@ static void sleep_mode_enter(void)
 
     NRF_LOG_INFO("Powering system off!");
     NRF_LOG_FLUSH();
-    err_code = sd_power_system_off();
+
+    // Enable wakeup from pin P0.14
+    nrf_gpio_cfg_sense_input(14, NRF_GPIO_PIN_PULLUP, NRF_GPIO_PIN_SENSE_LOW);
+
+#ifdef DEBUG_NRF
+    (void) sd_power_system_off();
+    NRF_LOG_INFO("Powered off");
     APP_ERROR_CHECK(err_code);
+    while(1);
+#else
+    err_code = sd_power_system_off();
+    NRF_LOG_INFO("Powered off");
+    nrf_buddy_led_on(3);
+    APP_ERROR_CHECK(err_code);
+#endif
 
     NRF_LOG_INFO("This should not be printed!");
 }
@@ -604,15 +617,6 @@ static void advertising_init(void)
     ble_advertising_conn_cfg_tag_set(&m_advertising, APP_BLE_CONN_CFG_TAG);
 }
 
-
-/**@brief Function for initializing power management.
- */
-static void power_management_init(void)
-{
-    ret_code_t err_code;
-    err_code = nrf_pwr_mgmt_init();
-    APP_ERROR_CHECK(err_code);
-}
 
 
 /**@brief Function for handling the idle state (main loop).

--- a/main.c
+++ b/main.c
@@ -281,24 +281,6 @@ void twi_master_init(void)
     nrf_drv_twi_enable(&m_twi);
 }
 
-void getADXL355AccelerometerData(int32_t *AccValue)
-{
-    if(adxl355_ReadAcc(&adxl355Sensor, &AccValue[0], &AccValue[1], &AccValue[2]) == true) // Read acc value from mpu6050 internal registers and save them in the array
-    {
-    
-      //float xGs = 9.81f*0.00000390625f * ((float)AccValue[0]);
-      //float yGs = 9.81f*0.00000390625f * ((float)AccValue[1]);
-      //float zGs = 9.81f*0.00000390625f * ((float)AccValue[2]);
-      
-      //NRF_LOG_RAW_INFO("x:" NRF_LOG_FLOAT_MARKER ", ", NRF_LOG_FLOAT(xGs) ); // display the read values
-      //NRF_LOG_RAW_INFO("y:" NRF_LOG_FLOAT_MARKER ", ", NRF_LOG_FLOAT(yGs) ); // display the read values
-      //NRF_LOG_RAW_INFO("z:" NRF_LOG_FLOAT_MARKER " ", NRF_LOG_FLOAT(zGs) ); // display the read values
-
-      //NRF_LOG_RAW_INFO("\n");
-      //NRF_LOG_FLUSH();
-    }
-}
-
 /**@brief Function for application main entry.
  */
 int main(void)


### PR DESCRIPTION
General cleanup has happened in this branch. Actual implementation of setting up the accelerometers to set a pin low on a threshold will be done in the sensors' library. 

This repo however now has pin 14 set as a wakeup pin meaning that after the device goes to sleep, when pin 14 transitions from high to low the nRF52840 is woken and resets.